### PR TITLE
HotFix for binder driver build error if binder enabled in kernel config

### DIFF
--- a/binder/binder.c
+++ b/binder/binder.c
@@ -152,7 +152,7 @@ static uint32_t binder_debug_mask = BINDER_DEBUG_USER_ERROR |
 //yangbin tmp comments because it will cause crash when we insmod
 //module_param_named(debug_mask, binder_debug_mask, uint, S_IWUSR | S_IRUGO);
 
-static char *binder_devices_param = CONFIG_ANDROID_BINDER_DEVICES;
+static char *binder_devices_param = (strcmp(CONFIG_ANDROID_BINDER_DEVICES, "")) ? CONFIG_ANDROID_BINDER_DEVICES : "hostbinder,hostvndbinder,hosthwbinder";
 module_param_named(devices, binder_devices_param, charp, 0444);
 
 static DECLARE_WAIT_QUEUE_HEAD(binder_user_error_wait);


### PR DESCRIPTION
This is a tmp fix. Need to backport binderfs code from kernel 5.0.X

Tracked-On: OAM-86838
Signed-off-by: Wang, Liang <liang.wang@intel.com>