### PR TITLE
Update binderfs_device to be same as kernel 5.4 and above

### DIFF
--- a/binder/binder_ctl.h
+++ b/binder/binder_ctl.h
@@ -22,8 +22,8 @@
  */
 struct binderfs_device {
 	char name[BINDERFS_MAX_NAME + 1];
-	__u8 major;
-	__u8 minor;
+	__u32 major;
+	__u32 minor;
 };
 
 /**


### PR DESCRIPTION
binderfs_device used in android-entry is updated to be compatible
with inbuilt kernel binderfs module. In order to be compatible
with android-entry, binderfs_device structure updated.

Tracked-On: OAM-89615
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>